### PR TITLE
Enable NIfTI input and update threshold overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pip install PyQt5 matplotlib numpy pydicom nibabel scikit-image vtk
     ```
 
 2. **Carga un estudio CT** (botón `Cargar DICOM/NIfTI`):
-    - Selecciona una carpeta con archivos DICOM (`.dcm`) **o** un archivo NIfTI (`.nii` o `.nii.gz`).
+    - Elige un archivo NIfTI (`.nii`/`.nii.gz`) o selecciona una carpeta con archivos DICOM (`.dcm`).
 
 3. **Navega y explora el volumen en 2D**:
     - Cambia la orientación (Axial/Coronal/Sagital).


### PR DESCRIPTION
## Summary
- allow selecting a `.nii` file directly for volume loading
- warn when the chosen folder has no DICOM files
- refresh 2D mask overlay when changing threshold
- clarify NIfTI instructions in the README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a3ba19f888329a57e138bcceb4078